### PR TITLE
feat(sign): inline login modal and fix post-login redirect

### DIFF
--- a/src/components/KeychainLoginForm.tsx
+++ b/src/components/KeychainLoginForm.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { getKeychain } from '@/lib/keychain'
+import { decryptKeys } from '@/lib/keychain-helpers'
+import { useAuthStore } from '@/stores/auth'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useTranslation } from '@/i18n'
+
+interface KeychainLoginFormProps {
+  /** Called after a successful login. */
+  onSuccess?: () => void
+  /** Pre-select account when available in keychain. */
+  preferredUsername?: string
+  /** Prefix for input ids when multiple forms may exist on one page. */
+  idPrefix?: string
+  /** Show link to import page below the form. */
+  showImportLink?: boolean
+}
+
+export function KeychainLoginForm({
+  onSuccess,
+  preferredUsername,
+  idPrefix = 'login',
+  showImportLink = true,
+}: KeychainLoginFormProps) {
+  const { t } = useTranslation()
+  const login = useAuthStore((s) => s.login)
+  const [username, setUsername] = useState('')
+  const [keychainPassword, setKeychainPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [keychain, setKeychain] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    const stored = getKeychain()
+    setKeychain(stored)
+    const usernames = Object.keys(stored)
+    if (usernames.length === 0) return
+    if (preferredUsername && stored[preferredUsername]) {
+      setUsername(preferredUsername)
+      return
+    }
+    setUsername((current) => current || usernames[0])
+  }, [preferredUsername])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    if (!username || !keychainPassword) {
+      setError(t('login.errorRequired'))
+      return
+    }
+    const encrypted = keychain[username]
+    if (!encrypted) {
+      setError(t('login.errorNotFound'))
+      return
+    }
+    setLoading(true)
+    try {
+      const keys = await decryptKeys(encrypted, keychainPassword)
+      await login(username, keys)
+      setKeychainPassword('')
+      onSuccess?.()
+    } catch {
+      setError(t('login.errorInvalid'))
+    }
+    setLoading(false)
+  }
+
+  const keychainUsers = Object.keys(keychain)
+  const usernameId = `${idPrefix}-username`
+  const passwordId = `${idPrefix}-password`
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor={usernameId}>{t('login.usernameLabel')}</Label>
+          <Select
+            value={username || '__none'}
+            onValueChange={(v) => setUsername(v === '__none' ? '' : v)}
+          >
+            <SelectTrigger id={usernameId}>
+              <SelectValue placeholder={t('login.usernamePlaceholder')} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__none" className="text-muted-foreground">
+                {t('login.selectUser')}
+              </SelectItem>
+              {keychainUsers.map((u) => (
+                <SelectItem key={u} value={u}>
+                  {u}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={passwordId}>{t('login.passwordLabel')}</Label>
+          <Input
+            id={passwordId}
+            type="password"
+            value={keychainPassword}
+            onChange={(e) => setKeychainPassword(e.target.value)}
+            autoComplete="current-password"
+          />
+        </div>
+        {error && <p className="text-destructive text-sm">{error}</p>}
+        <Button type="submit" disabled={loading} className="w-full">
+          {loading ? t('login.loggingIn') : t('common.login')}
+        </Button>
+      </form>
+      {showImportLink && (
+        <p className="text-center text-sm text-muted-foreground">
+          <Link to="/import" className="underline">
+            {t('common.import')}
+          </Link>
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,15 +1,25 @@
 import { useEffect } from 'react'
 import { Link, useLocation, useNavigate, Outlet } from 'react-router-dom'
+import { buildSignReturnPath } from '@/lib/sign-path'
 import { sendPageView } from '@/lib/gtag'
 import { useAuthStore } from '@/stores/auth'
 import { useTranslation } from '@/i18n'
 
 export function Layout() {
-  const { pathname } = useLocation()
+  const { pathname, search } = useLocation()
   const navigate = useNavigate()
   const username = useAuthStore((s) => s.username)
   const logout = useAuthStore((s) => s.logout)
   const { t } = useTranslation()
+
+  const loginHref = (() => {
+    if (!pathname.startsWith('/sign/')) return '/login'
+    const pathMatch = pathname.slice('/sign/'.length)
+    const uri = `steem://sign/${pathMatch}${search}`
+    const returnPath = buildSignReturnPath(uri, 'active')
+    if (!returnPath) return '/login'
+    return `/login?redirect=${encodeURIComponent(uri)}`
+  })()
 
   useEffect(() => {
     sendPageView(pathname)
@@ -44,7 +54,7 @@ export function Layout() {
               </button>
             </>
           ) : (
-            <Link to="/login" className="hover:text-foreground">
+            <Link to={loginHref} className="hover:text-foreground">
               {t('common.login')}
             </Link>
           )}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react'
+import { XIcon } from 'lucide-react'
+import { Dialog as DialogPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        'fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg',
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-lg font-semibold leading-none', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/i18n/translations.json
+++ b/src/i18n/translations.json
@@ -82,7 +82,8 @@
       "blockNum": "Block: {{block}}",
       "callbackNotice": "You will be redirected after signing.",
       "authorityNotice": "This transaction requires your {{authority}} key.",
-      "continueToLogin": "Continue to login"
+      "continueToLogin": "Continue to login",
+      "loginDialogDescription": "Log in to review and sign this transaction."
     },
     "dashboard": {
       "title": "Dashboard",
@@ -233,7 +234,8 @@
       "blockNum": "区块: {{block}}",
       "callbackNotice": "签名后您将被重定向。",
       "authorityNotice": "此交易需要您的 {{authority}} 密钥。",
-      "continueToLogin": "继续登录"
+      "continueToLogin": "继续登录",
+      "loginDialogDescription": "登录后即可查看并签名此交易。"
     },
     "dashboard": {
       "title": "控制台",

--- a/src/lib/sign-path.ts
+++ b/src/lib/sign-path.ts
@@ -9,6 +9,50 @@ export const ALLOWED_AUTHORITIES = ['active', 'posting'] as const
 /** Type + payload: ops|op|tx and base64url chars only (incl. '.' for padding). */
 const SIGN_PAYLOAD_REGEX = /^(ops|op|tx)\/[A-Za-z0-9_.-]+$/
 
+const ACCOUNT_NAME_REGEX = /^[a-z0-9.-]{1,16}$/i
+const BASE64U_REGEX = /^[A-Za-z0-9_.-]+$/
+
+function sanitizeSignQuery(search: string): string {
+  if (!search) return ''
+  const raw = search.startsWith('?') ? search.slice(1) : search
+  if (!raw) return ''
+  const params = new URLSearchParams(raw)
+  const out = new URLSearchParams()
+
+  const signer = params.get('s')?.trim()
+  if (signer && ACCOUNT_NAME_REGEX.test(signer)) {
+    out.set('s', signer)
+  }
+
+  const authority = params.get('authority')
+  if (authority && ALLOWED_AUTHORITIES.includes(authority as (typeof ALLOWED_AUTHORITIES)[number])) {
+    out.set('authority', authority)
+  }
+
+  if (params.has('nb')) {
+    out.set('nb', '')
+  }
+
+  const callback = params.get('cb')?.trim()
+  if (callback && BASE64U_REGEX.test(callback)) {
+    out.set('cb', callback)
+  }
+
+  const qs = out.toString()
+  return qs ? `?${qs}` : ''
+}
+
+function extractSignPathAndQuery(pathPart: string): { signPath: string; query: string } {
+  const qIdx = pathPart.indexOf('?')
+  if (qIdx < 0) {
+    return { signPath: pathPart, query: '' }
+  }
+  return {
+    signPath: pathPart.slice(0, qIdx),
+    query: pathPart.slice(qIdx),
+  }
+}
+
 /**
  * Returns true if pathMatch (the part after /sign/) is safe: type is ops/op/tx and
  * payload segment contains only base64url chars. Rejects path traversal ('..' as a
@@ -37,16 +81,33 @@ export function sanitizeRedirectPath(redirectUri: string): string | null {
     return null
   }
   const pathPart = redirectUri.replace(/^steem:\/\/sign\//, '').trim()
-  // Reject '..' only when it appears as a standalone path segment (path traversal),
-  // not as base64u padding inside the payload string.
-  const segments = pathPart.split('/')
-  if (segments.some((s) => s === '..') || /[\0\r\n]/.test(pathPart)) {
+  const { signPath, query } = extractSignPathAndQuery(pathPart)
+  if (/[\0\r\n]/.test(signPath)) {
     return null
   }
-  if (!SIGN_PAYLOAD_REGEX.test(pathPart)) {
+  if (!isValidSignPath(signPath)) {
     return null
   }
-  return pathPart
+  return signPath + sanitizeSignQuery(query)
+}
+
+/**
+ * Build a safe /sign/... return path after login from redirect + optional authority.
+ */
+export function buildSignReturnPath(
+  redirectUri: string | null | undefined,
+  authority: string
+): string | null {
+  const pathPart = redirectUri ? sanitizeRedirectPath(redirectUri) : null
+  if (pathPart === null) return null
+
+  const safeAuthority = sanitizeAuthority(authority, 'active')
+  if (safeAuthority === 'active' || pathPart.includes('authority=')) {
+    return `/sign/${pathPart}`
+  }
+
+  const sep = pathPart.includes('?') ? '&' : '?'
+  return `/sign/${pathPart}${sep}authority=${safeAuthority}`
 }
 
 /**

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,70 +1,19 @@
-import { useState, useEffect } from 'react'
 import { useNavigate, Link, useSearchParams } from 'react-router-dom'
-import { getKeychain } from '@/lib/keychain'
-import { decryptKeys } from '@/lib/keychain-helpers'
-import { useAuthStore } from '@/stores/auth'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
+import { KeychainLoginForm } from '@/components/KeychainLoginForm'
 import { useTranslation } from '@/i18n'
-import { sanitizeRedirectPath, sanitizeAuthority } from '@/lib/sign-path'
+import { buildSignReturnPath, sanitizeAuthority } from '@/lib/sign-path'
 
 export function Login() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
-  const login = useAuthStore((s) => s.login)
   const redirectParam = searchParams.get('redirect')
-  const [username, setUsername] = useState('')
-  const [keychainPassword, setKeychainPassword] = useState('')
-  const [error, setError] = useState('')
-  const [loading, setLoading] = useState(false)
-  const [keychain, setKeychain] = useState<Record<string, string>>({})
+  const authority = sanitizeAuthority(searchParams.get('authority'), 'active')
 
-  useEffect(() => {
-    setKeychain(getKeychain())
-    const usernames = Object.keys(getKeychain())
-    if (usernames.length > 0 && !username) setUsername(usernames[0])
-  }, [])
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    setError('')
-    if (!username || !keychainPassword) {
-      setError(t('login.errorRequired'))
-      return
-    }
-    const encrypted = keychain[username]
-    if (!encrypted) {
-      setError(t('login.errorNotFound'))
-      return
-    }
-    setLoading(true)
-    try {
-      const keys = await decryptKeys(encrypted, keychainPassword)
-      await login(username, keys)
-      // Return to sign page only if redirect is a valid, safe sign path (no path traversal / injection)
-      const pathPart = redirectParam ? sanitizeRedirectPath(redirectParam) : null
-      const authority = sanitizeAuthority(searchParams.get('authority'), 'active')
-      if (pathPart !== null) {
-        navigate(`/sign/${pathPart}${authority !== 'active' ? `?authority=${authority}` : ''}`)
-      } else {
-        navigate('/dashboard')
-      }
-    } catch (err) {
-      setError(t('login.errorInvalid'))
-    }
-    setLoading(false)
+  function handleSuccess() {
+    const returnPath = buildSignReturnPath(redirectParam, authority)
+    navigate(returnPath ?? '/dashboard')
   }
-
-  const keychainUsers = Object.keys(keychain)
 
   return (
     <div className="max-w-2xl mx-auto w-full flex flex-col gap-6">
@@ -72,50 +21,7 @@ export function Login() {
         <div className="leading-none font-semibold">{t('login.title')}</div>
         <p className="text-muted-foreground text-sm mt-2">{t('login.description')}</p>
       </div>
-      <div className="space-y-4">
-        <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="username">{t('login.usernameLabel')}</Label>
-              <Select
-                value={username || '__none'}
-                onValueChange={(v) => setUsername(v === '__none' ? '' : v)}
-              >
-                <SelectTrigger id="username">
-                  <SelectValue placeholder={t('login.usernamePlaceholder')} />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none" className="text-muted-foreground">
-                    {t('login.selectUser')}
-                  </SelectItem>
-                  {keychainUsers.map((u) => (
-                    <SelectItem key={u} value={u}>
-                      {u}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="keychain-password">{t('login.passwordLabel')}</Label>
-              <Input
-                id="keychain-password"
-                type="password"
-                value={keychainPassword}
-                onChange={(e) => setKeychainPassword(e.target.value)}
-                autoComplete="current-password"
-              />
-            </div>
-            {error && <p className="text-destructive text-sm">{error}</p>}
-            <Button type="submit" disabled={loading} className="w-full">
-              {loading ? t('login.loggingIn') : t('common.login')}
-            </Button>
-          </form>
-          <p className="text-center text-sm text-muted-foreground">
-            <Link to="/import" className="underline">
-              {t('common.import')}
-            </Link>
-          </p>
-      </div>
+      <KeychainLoginForm onSuccess={handleSuccess} />
       <p className="mt-4 text-center text-sm">
         <Link to="/" className="text-muted-foreground hover:underline">
           {t('common.backToHome')}

--- a/src/pages/Sign.tsx
+++ b/src/pages/Sign.tsx
@@ -1,13 +1,22 @@
 import { useState, useEffect } from 'react'
-import { useParams, useSearchParams, useNavigate, Link } from 'react-router-dom'
+import { useParams, useSearchParams, useNavigate } from 'react-router-dom'
 import { decode, resolveTransaction, resolveCallback, type ParsedSteemUri } from '@/lib/steem-uri'
 import { isValidSignPath } from '@/lib/sign-path'
 import { broadcastTransaction } from '@/lib/steem'
 import { useAuthStore } from '@/stores/auth'
 import { getAuthority } from '@/lib/auth'
 import type { KeysMap } from '@/lib/auth'
+import { hasAccounts } from '@/lib/keychain'
 import { CheckCircle, XCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { KeychainLoginForm } from '@/components/KeychainLoginForm'
 import { OperationItem } from '@/components/Operation'
 import { useTranslation } from '@/i18n'
 
@@ -28,6 +37,7 @@ export function Sign() {
   const [blockNum, setBlockNum] = useState<number | null>(null)
   const [failed, setFailed] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [loginOpen, setLoginOpen] = useState(false)
 
   const pathSafe = isValidSignPath(pathMatch)
   const uri = pathSafe
@@ -153,14 +163,37 @@ export function Sign() {
         ) : null}
         {!username || !hasRequiredKey ? (
           <div className="flex gap-2 flex-wrap">
-            <Button asChild variant="default">
-              <Link to={`/login?redirect=${encodeURIComponent(uri)}&authority=${authority}`}>
-                {t('sign.continueToLogin')}
-              </Link>
+            <Button
+              type="button"
+              variant="default"
+              onClick={() => {
+                if (hasAccounts()) {
+                  setLoginOpen(true)
+                } else {
+                  navigate('/import')
+                }
+              }}
+            >
+              {t('sign.continueToLogin')}
             </Button>
             <Button type="button" variant="outline" onClick={() => navigate(-1)}>
               {t('common.back')}
             </Button>
+            <Dialog open={loginOpen} onOpenChange={setLoginOpen}>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>{t('login.title')}</DialogTitle>
+                  <DialogDescription>{t('sign.loginDialogDescription')}</DialogDescription>
+                </DialogHeader>
+                <KeychainLoginForm
+                  idPrefix="sign-login"
+                  preferredUsername={
+                    typeof parsed.params?.signer === 'string' ? parsed.params.signer : undefined
+                  }
+                  onSuccess={() => setLoginOpen(false)}
+                />
+              </DialogContent>
+            </Dialog>
           </div>
         ) : (
           <>

--- a/src/test/lib/sign-path.test.ts
+++ b/src/test/lib/sign-path.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { buildSignReturnPath, isValidSignPath, sanitizeRedirectPath } from '@/lib/sign-path'
+
+const SAMPLE_OPS_PATH = 'ops/W1siYWNjb3VudF91cGRhdGUiXX0.'
+
+describe('sign-path', () => {
+  it('accepts ops path with base64u padding dots', () => {
+    expect(isValidSignPath('ops/W1..')).toBe(true)
+  })
+
+  it('sanitizeRedirectPath strips and preserves safe query params', () => {
+    const uri = `steem://sign/${SAMPLE_OPS_PATH}?s=ety001`
+    expect(sanitizeRedirectPath(uri)).toBe(`${SAMPLE_OPS_PATH}?s=ety001`)
+  })
+
+  it('sanitizeRedirectPath rejects unsafe query params', () => {
+    const uri = `steem://sign/${SAMPLE_OPS_PATH}?next=https://evil.test`
+    expect(sanitizeRedirectPath(uri)).toBe(SAMPLE_OPS_PATH)
+  })
+
+  it('buildSignReturnPath returns sign route with query', () => {
+    const uri = `steem://sign/${SAMPLE_OPS_PATH}?s=ety001`
+    expect(buildSignReturnPath(uri, 'active')).toBe(`/sign/${SAMPLE_OPS_PATH}?s=ety001`)
+  })
+
+  it('buildSignReturnPath appends posting authority when needed', () => {
+    const uri = `steem://sign/${SAMPLE_OPS_PATH}?s=ety001`
+    expect(buildSignReturnPath(uri, 'posting')).toBe(
+      `/sign/${SAMPLE_OPS_PATH}?s=ety001&authority=posting`
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Add an inline login dialog on the sign page so users stay on the pending transaction while authenticating.
- Extract a shared `KeychainLoginForm` used by both the sign modal and the standalone login page.
- Fix post-login redirect when steem URIs include query params (e.g. `?s=ety001`), which previously failed validation and sent users to `/dashboard`.
- Preserve sign-page context when using the footer Login link on `/sign/*` routes.

## Test plan
- [ ] Visit `/sign/ops/...?s=ety001` while logged out; click Continue to login and verify the modal opens and closes after successful login, leaving Approve visible.
- [ ] Visit `/sign/ops/...?s=ety001`, use footer Login, complete login on `/login`, and confirm redirect back to the same sign URL (not `/dashboard`).
- [ ] Verify standalone `/login` without redirect still lands on `/dashboard`.
- [ ] Run `pnpm run build`.
- [ ] Run `pnpm test:run src/test/lib/sign-path.test.ts` (if vitest env allows).