### PR TITLE
feat(login): manage saved keychain accounts on login page

### DIFF
--- a/src/components/KeychainLoginForm.tsx
+++ b/src/components/KeychainLoginForm.tsx
@@ -24,6 +24,8 @@ interface KeychainLoginFormProps {
   idPrefix?: string
   /** Show link to import page below the form. */
   showImportLink?: boolean
+  /** Bump to reload accounts after keychain changes (e.g. remove on Login page). */
+  keychainRevision?: number
 }
 
 export function KeychainLoginForm({
@@ -31,6 +33,7 @@ export function KeychainLoginForm({
   preferredUsername,
   idPrefix = 'login',
   showImportLink = true,
+  keychainRevision = 0,
 }: KeychainLoginFormProps) {
   const { t } = useTranslation()
   const login = useAuthStore((s) => s.login)
@@ -44,13 +47,16 @@ export function KeychainLoginForm({
     const stored = getKeychain()
     setKeychain(stored)
     const usernames = Object.keys(stored)
-    if (usernames.length === 0) return
+    if (usernames.length === 0) {
+      setUsername('')
+      return
+    }
     if (preferredUsername && stored[preferredUsername]) {
       setUsername(preferredUsername)
       return
     }
-    setUsername((current) => current || usernames[0])
-  }, [preferredUsername])
+    setUsername((current) => (current && stored[current] ? current : usernames[0]))
+  }, [preferredUsername, keychainRevision])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()

--- a/src/components/SavedKeychainAccounts.tsx
+++ b/src/components/SavedKeychainAccounts.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Trash2 } from 'lucide-react'
+import { getKeychain, hasAccounts, removeFromKeychain } from '@/lib/keychain'
+import { useTranslation } from '@/i18n'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+interface SavedKeychainAccountsProps {
+  /** Incremented by parent to reload the list after external keychain changes. */
+  revision?: number
+  onAccountsChange?: () => void
+}
+
+export function SavedKeychainAccounts({
+  revision = 0,
+  onAccountsChange,
+}: SavedKeychainAccountsProps) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [pendingRemove, setPendingRemove] = useState<string | null>(null)
+
+  const usernames = Object.keys(getKeychain()).sort((a, b) =>
+    a.localeCompare(b, undefined, { sensitivity: 'base' })
+  )
+
+  if (usernames.length === 0) {
+    return null
+  }
+
+  function handleConfirmRemove() {
+    if (!pendingRemove) return
+    removeFromKeychain(pendingRemove)
+    setPendingRemove(null)
+    onAccountsChange?.()
+    if (!hasAccounts()) {
+      navigate('/import', { replace: true })
+    }
+  }
+
+  return (
+    <>
+      <div className="border rounded-lg overflow-hidden">
+        <div className="px-3 py-2 bg-muted/50 border-b">
+          <div className="text-sm font-medium">{t('login.savedAccountsTitle')}</div>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {t('login.savedAccountsDescription')}
+          </p>
+        </div>
+        <ul className="divide-y divide-border">
+          {usernames.map((name) => (
+            <li
+              key={`${name}-${revision}`}
+              className="flex items-center justify-between gap-3 px-3 py-2.5"
+            >
+              <span className="font-mono text-sm truncate">{name}</span>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="shrink-0 text-destructive hover:text-destructive"
+                onClick={() => setPendingRemove(name)}
+                aria-label={t('login.removeFromDeviceAria', { username: name })}
+              >
+                <Trash2 className="size-4 mr-1.5" aria-hidden />
+                {t('login.removeFromDevice')}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <Dialog
+        open={pendingRemove !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingRemove(null)
+        }}
+      >
+        <DialogContent showCloseButton>
+          <DialogHeader>
+            <DialogTitle>{t('login.removeConfirmTitle')}</DialogTitle>
+            <DialogDescription>
+              {t('login.removeConfirmDescription', { username: pendingRemove ?? '' })}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => setPendingRemove(null)}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="button" variant="destructive" onClick={handleConfirmRemove}>
+              {t('login.removeConfirmAction')}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/i18n/translations.json
+++ b/src/i18n/translations.json
@@ -33,7 +33,14 @@
       "loggingIn": "Logging in…",
       "errorRequired": "Username and keychain password are required.",
       "errorNotFound": "Account not found in keychain.",
-      "errorInvalid": "Invalid keychain password or credentials."
+      "errorInvalid": "Invalid keychain password or credentials.",
+      "savedAccountsTitle": "Saved on this device",
+      "savedAccountsDescription": "Encrypted keys stored in this browser. Removing an account only deletes local data.",
+      "removeFromDevice": "Remove",
+      "removeFromDeviceAria": "Remove {{username}} from this device",
+      "removeConfirmTitle": "Remove saved account?",
+      "removeConfirmDescription": "Remove @{{username}} from this browser? Your Steem account on the blockchain is not affected. You can import again later.",
+      "removeConfirmAction": "Remove from device"
     },
     "import": {
       "title": "Import account",
@@ -185,7 +192,14 @@
       "loggingIn": "正在登录…",
       "errorRequired": "用户名和钥匙串密码为必填项。",
       "errorNotFound": "未在钥匙串中找到该账户。",
-      "errorInvalid": "钥匙串密码或凭证无效。"
+      "errorInvalid": "钥匙串密码或凭证无效。",
+      "savedAccountsTitle": "本机已保存的账户",
+      "savedAccountsDescription": "密钥已加密保存在本浏览器中。移除仅删除本地数据。",
+      "removeFromDevice": "移除",
+      "removeFromDeviceAria": "从本机移除 {{username}}",
+      "removeConfirmTitle": "移除已保存的账户？",
+      "removeConfirmDescription": "从本浏览器移除 @{{username}}？链上 Steem 账户不受影响，之后可重新导入。",
+      "removeConfirmAction": "从本机移除"
     },
     "import": {
       "title": "导入账户",

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,11 +1,14 @@
+import { useState } from 'react'
 import { useNavigate, Link, useSearchParams } from 'react-router-dom'
 import { KeychainLoginForm } from '@/components/KeychainLoginForm'
+import { SavedKeychainAccounts } from '@/components/SavedKeychainAccounts'
 import { useTranslation } from '@/i18n'
 import { buildSignReturnPath, sanitizeAuthority } from '@/lib/sign-path'
 
 export function Login() {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const [keychainRevision, setKeychainRevision] = useState(0)
   const [searchParams] = useSearchParams()
   const redirectParam = searchParams.get('redirect')
   const authority = sanitizeAuthority(searchParams.get('authority'), 'active')
@@ -21,7 +24,16 @@ export function Login() {
         <div className="leading-none font-semibold">{t('login.title')}</div>
         <p className="text-muted-foreground text-sm mt-2">{t('login.description')}</p>
       </div>
-      <KeychainLoginForm onSuccess={handleSuccess} />
+      <div className="space-y-6">
+        <KeychainLoginForm
+          onSuccess={handleSuccess}
+          keychainRevision={keychainRevision}
+        />
+        <SavedKeychainAccounts
+          revision={keychainRevision}
+          onAccountsChange={() => setKeychainRevision((n) => n + 1)}
+        />
+      </div>
       <p className="mt-4 text-center text-sm">
         <Link to="/" className="text-muted-foreground hover:underline">
           {t('common.backToHome')}


### PR DESCRIPTION
## Summary

- Add a **Saved on this device** section on `/login` listing all keychain usernames with a remove action.
- Confirm before removal; copy clarifies that only local encrypted data is deleted (blockchain account unchanged).
- Refresh the unlock dropdown after removal; redirect to `/import` when the keychain becomes empty.
- Add en/zh i18n strings for the new UI.

## Test plan

- [ ] Import an account with **Save in browser cache** enabled, then open `/login`.
- [ ] Verify saved accounts appear below the login form; unlock dropdown stays in sync.
- [ ] Remove one account via confirm dialog; remaining accounts still listed and selectable.
- [ ] Remove the last account; app redirects to `/import`.
- [ ] Switch language (en/zh) and confirm labels and confirm dialog text.