### PR TITLE
fix(sign): owner key for account_update with owner authority

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -14,6 +14,7 @@ interface CondenserAccount {
 }
 
 export interface KeysMap {
+  owner: string | null
   active: string | null
   posting: string | null
   memo: string | null
@@ -51,7 +52,7 @@ export async function credentialsValid(username: string, password: string): Prom
     const pubkey = auth.wifToPublic(password)
     return !!keysMap[pubkey]
   }
-  const privKeys = auth.getPrivateKeys(username, password, ['active', 'posting', 'memo'])
+  const privKeys = auth.getPrivateKeys(username, password, ['owner', 'active', 'posting', 'memo'])
   const activePub = privKeys.activePubkey ?? privKeys.active
   return !!(activePub && keysMap[activePub])
 }
@@ -59,7 +60,7 @@ export async function credentialsValid(username: string, password: string): Prom
 /** Get keys { active, posting, memo } - password can be account password or WIF. */
 export async function getKeys(username: string, password: string): Promise<KeysMap> {
   const accounts = await getAccountsCondenser([username])
-  const keys: KeysMap = { active: null, posting: null, memo: null }
+  const keys: KeysMap = { owner: null, active: null, posting: null, memo: null }
   if (!accounts.length) return keys
 
   const account = accounts[0] as CondenserAccount
@@ -69,13 +70,16 @@ export async function getKeys(username: string, password: string): Promise<KeysM
   if (auth.isWif(password)) {
     const pubkey = auth.wifToPublic(password)
     const type = keysMap[pubkey] as keyof KeysMap | undefined
-    if (type && (type === 'active' || type === 'posting' || type === 'memo')) {
+    if (type && (type === 'owner' || type === 'active' || type === 'posting' || type === 'memo')) {
       keys[type] = password
     }
     return keys
   }
 
-  const privKeys = auth.getPrivateKeys(username, password, ['active', 'posting', 'memo'])
+  const privKeys = auth.getPrivateKeys(username, password, ['owner', 'active', 'posting', 'memo'])
+  if (privKeys.ownerPubkey && keysMap[privKeys.ownerPubkey] === 'owner') {
+    keys.owner = privKeys.owner ?? null
+  }
   keys.active = privKeys.active ?? null
   keys.posting = privKeys.posting ?? null
   if (privKeys.memoPubkey && keysMap[privKeys.memoPubkey] === 'memo') {
@@ -85,6 +89,6 @@ export async function getKeys(username: string, password: string): Promise<KeysM
 }
 
 export function getAuthority(str: string | undefined, fallback: string): string {
-  if (str && ['active', 'posting'].includes(str)) return str
+  if (str && ['owner', 'active', 'posting'].includes(str)) return str
   return fallback
 }

--- a/src/lib/keychain-crypto.ts
+++ b/src/lib/keychain-crypto.ts
@@ -4,6 +4,7 @@
  */
 
 export interface KeysPayload {
+  owner: string | null
   active: string | null
   posting: string | null
   memo: string | null
@@ -133,8 +134,13 @@ export async function decryptKeys(
       ciphertextBuffer
     )
 
-    const keys = JSON.parse(new TextDecoder().decode(decrypted)) as KeysPayload
-    return keys
+    const raw = JSON.parse(new TextDecoder().decode(decrypted)) as Partial<KeysPayload>
+    return {
+      owner: raw.owner ?? null,
+      active: raw.active ?? null,
+      posting: raw.posting ?? null,
+      memo: raw.memo ?? null,
+    }
   } catch (err) {
     throw new Error(`Decryption failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
   }

--- a/src/lib/sign-path.ts
+++ b/src/lib/sign-path.ts
@@ -3,8 +3,8 @@
  * open redirect, and injection (XSS / unsafe URLs).
  */
 
-/** Allowed authority values for signing (subset of Steem key types). */
-export const ALLOWED_AUTHORITIES = ['active', 'posting'] as const
+/** Allowed authority values for signing (Steem key roles). */
+export const ALLOWED_AUTHORITIES = ['owner', 'active', 'posting'] as const
 
 /** Type + payload: ops|op|tx and base64url chars only (incl. '.' for padding). */
 const SIGN_PAYLOAD_REGEX = /^(ops|op|tx)\/[A-Za-z0-9_.-]+$/

--- a/src/lib/signing-authority.ts
+++ b/src/lib/signing-authority.ts
@@ -1,0 +1,88 @@
+import { sanitizeAuthority } from './sign-path'
+
+export type SigningAuthority = 'owner' | 'active' | 'posting' | 'memo'
+
+const AUTHORITY_RANK: Record<SigningAuthority, number> = {
+  memo: 0,
+  posting: 1,
+  active: 2,
+  owner: 3,
+}
+
+/** Operations that always require owner key when present in a transaction. */
+const OWNER_REQUIRED_OPS = new Set([
+  'account_create',
+  'account_create_with_delegation',
+  'claim_account',
+  'change_recovery_account',
+  'request_account_recovery',
+  'recover_account',
+  'reset_account',
+])
+
+function isPresentAuthorityField(value: unknown): boolean {
+  if (value == null || value === '') return false
+  if (Array.isArray(value)) return value.length > 0
+  if (typeof value === 'object') {
+    const auth = value as { key_auths?: unknown[]; account_auths?: unknown[] }
+    const keyAuths = auth.key_auths
+    const accountAuths = auth.account_auths
+    if (Array.isArray(keyAuths) && keyAuths.length > 0) return true
+    if (Array.isArray(accountAuths) && accountAuths.length > 0) return true
+  }
+  return true
+}
+
+function authorityForOperation(type: string, payload: unknown): SigningAuthority | null {
+  if (OWNER_REQUIRED_OPS.has(type)) return 'owner'
+
+  if (type === 'account_update' && payload && typeof payload === 'object' && !Array.isArray(payload)) {
+    const data = payload as Record<string, unknown>
+    if (isPresentAuthorityField(data.owner)) return 'owner'
+    return 'active'
+  }
+
+  if (type === 'custom_json' && payload && typeof payload === 'object' && !Array.isArray(payload)) {
+    const data = payload as {
+      required_auths?: unknown[]
+      required_posting_auths?: unknown[]
+    }
+    const reqAuths = data.required_auths
+    const reqPosting = data.required_posting_auths
+    if (Array.isArray(reqAuths) && reqAuths.length > 0) return 'active'
+    if (Array.isArray(reqPosting) && reqPosting.length > 0) return 'posting'
+  }
+
+  return null
+}
+
+function maxAuthority(a: SigningAuthority, b: SigningAuthority): SigningAuthority {
+  return AUTHORITY_RANK[a] >= AUTHORITY_RANK[b] ? a : b
+}
+
+/**
+ * Pick the Steem key role required to sign a transaction.
+ * Operation requirements override a weaker `authority` query param (e.g. active → owner).
+ */
+export function resolveSigningAuthority(
+  operations: unknown[],
+  preferred?: string | null
+): SigningAuthority {
+  let required: SigningAuthority = 'active'
+
+  if (Array.isArray(operations)) {
+    for (const op of operations) {
+      if (!Array.isArray(op) || op.length !== 2) continue
+      const [type, payload] = op
+      if (typeof type !== 'string') continue
+      const opAuthority = authorityForOperation(type, payload)
+      if (opAuthority) required = maxAuthority(required, opAuthority)
+    }
+  }
+
+  const preferredSafe = sanitizeAuthority(preferred ?? undefined, 'active') as SigningAuthority
+  if (AUTHORITY_RANK[required] > AUTHORITY_RANK[preferredSafe]) {
+    return required
+  }
+  return preferredSafe
+}

--- a/src/pages/Sign.tsx
+++ b/src/pages/Sign.tsx
@@ -4,7 +4,7 @@ import { decode, resolveTransaction, resolveCallback, type ParsedSteemUri } from
 import { isValidSignPath } from '@/lib/sign-path'
 import { broadcastTransaction } from '@/lib/steem'
 import { useAuthStore } from '@/stores/auth'
-import { getAuthority } from '@/lib/auth'
+import { resolveSigningAuthority } from '@/lib/signing-authority'
 import type { KeysMap } from '@/lib/auth'
 import { hasAccounts } from '@/lib/keychain'
 import { CheckCircle, XCircle } from 'lucide-react'
@@ -29,7 +29,6 @@ export function Sign() {
   const username = useAuthStore((s) => s.username)
   const keys = useAuthStore((s) => s.keys)
   const signTx = useAuthStore((s) => s.signTx)
-  const authority = getAuthority(searchParams.get('authority') ?? undefined, 'active')
   const [parsed, setParsed] = useState<ParsedSteemUri | null>(null)
   const [uriValid, setUriValid] = useState(true)
   const [loading, setLoading] = useState(false)
@@ -69,7 +68,13 @@ export function Sign() {
     }
   }, [uri, pathSafe])
 
-  const hasRequiredKey = username && ((keys as KeysMap)[authority as keyof KeysMap] ?? keys.active)
+  const authority = resolveSigningAuthority(
+    parsed?.tx?.operations ?? [],
+    searchParams.get('authority')
+  )
+
+  const hasRequiredKey =
+    username && !!(keys as KeysMap)[authority as keyof KeysMap]
 
   async function handleApprove() {
     if (!parsed || !username) return

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -16,13 +16,13 @@ interface AuthState {
   login: (username: string, keys: KeysMap) => Promise<void>
   logout: () => void
   loadAccount: () => Promise<void>
-  /** Sign tx with given authority (active | posting | memo); returns signed tx. */
+  /** Sign tx with given authority (owner | active | posting | memo); returns signed tx. */
   signTx: (tx: unknown, authority: string) => Promise<unknown>
 }
 
 export const useAuthStore = create<AuthState>((set, get) => ({
   username: null,
-  keys: { active: null, posting: null, memo: null },
+  keys: { owner: null, active: null, posting: null, memo: null },
   account: null,
 
   login: async (username, keys) => {
@@ -36,7 +36,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   },
 
   logout: () => {
-    set({ username: null, keys: { active: null, posting: null, memo: null }, account: null })
+    set({ username: null, keys: { owner: null, active: null, posting: null, memo: null }, account: null })
   },
 
   loadAccount: async () => {
@@ -48,8 +48,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   signTx: async (tx, authority) => {
     const { keys } = get()
-    const wif = (authority && keys[authority as keyof KeysMap]) ?? keys.active ?? keys.posting ?? keys.memo
-    if (!wif) throw new Error('No key for authority')
+    const role = authority as keyof KeysMap
+    const wif = keys[role]
+    if (!wif) throw new Error(`No key for authority: ${authority}`)
     const { signTransaction } = await import('@/lib/steem')
     return signTransaction(tx, [wif])
   },

--- a/src/test/lib/sign-path.test.ts
+++ b/src/test/lib/sign-path.test.ts
@@ -29,4 +29,11 @@ describe('sign-path', () => {
       `/sign/${SAMPLE_OPS_PATH}?s=ety001&authority=posting`
     )
   })
+
+  it('buildSignReturnPath appends owner authority when needed', () => {
+    const uri = `steem://sign/${SAMPLE_OPS_PATH}?s=ety001`
+    expect(buildSignReturnPath(uri, 'owner')).toBe(
+      `/sign/${SAMPLE_OPS_PATH}?s=ety001&authority=owner`
+    )
+  })
 })

--- a/src/test/lib/signing-authority.test.ts
+++ b/src/test/lib/signing-authority.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { resolveSigningAuthority } from '@/lib/signing-authority'
+
+describe('resolveSigningAuthority', () => {
+  it('requires owner when account_update includes owner authority', () => {
+    const ops = [
+      [
+        'account_update',
+        {
+          account: 'ety001',
+          owner: { weight_threshold: 1, account_auths: [], key_auths: [['STM6rv8rLaJtnhfgQKXbPsfDNscMd79J7pVrG8uVy3PTL4dEMBPz3', 1]] },
+          active: { weight_threshold: 1, account_auths: [], key_auths: [['STM6z4ueBGtT96KczqAEzQQTxPUkX5FTVKMEjRb1viFeS2eBSGgKu', 1]] },
+          posting: { weight_threshold: 1, account_auths: [], key_auths: [['STM5wP3YpAjReNzHgap6JxjXV56HMkto7NVY9WtsQNBXqM8mzdBmG', 1]] },
+          memo_key: 'STM5BPufai2nKA6m14LGpXi6aVMGPbCFNiT4WiK6GdMgVVTRNm4Ad',
+          json_metadata: '{}',
+        },
+      ],
+    ]
+    expect(resolveSigningAuthority(ops, 'active')).toBe('owner')
+  })
+
+  it('keeps active for account_update without owner field', () => {
+    const ops = [
+      [
+        'account_update',
+        {
+          account: 'ety001',
+          json_metadata: '{"profile":{}}',
+        },
+      ],
+    ]
+    expect(resolveSigningAuthority(ops, null)).toBe('active')
+  })
+
+  it('honors posting query for custom_json posting auth', () => {
+    const ops = [
+      [
+        'custom_json',
+        {
+          required_auths: [],
+          required_posting_auths: ['ety001'],
+          id: 'follow',
+          json: '{}',
+        },
+      ],
+    ]
+    expect(resolveSigningAuthority(ops, 'posting')).toBe('posting')
+  })
+})


### PR DESCRIPTION
## Summary

- Derive and store the **owner** WIF from master password (or owner WIF import); extend keychain payload with backward-compatible decrypt.
- Auto-detect required signing role from transaction ops (`account_update` with `owner` field → owner authority).
- Stop falling back to active when the resolved authority key is missing; allow `authority=owner` in sign URLs.

Fixes `missing required owner authority` when signing `steem://sign/ops/...` URIs that include an `owner` field in `account_update` (e.g. full authority rotation).

## Test plan

- [ ] Re-import account with master password so keychain includes owner key
- [ ] Sign `account_update` URI that includes `owner` — broadcast succeeds
- [ ] Sign posting-only `account_update` (no `owner` field) — still uses active key
- [ ] `npm run build` passes